### PR TITLE
[SECURITY] Migrate JWT tokens from localStorage to httpOnly cookies (#22)

### DIFF
--- a/src/backend/src/api/auth.ts
+++ b/src/backend/src/api/auth.ts
@@ -6,13 +6,13 @@ import { validateBody } from '../middleware/validation';
 import {
   loginSchema,
   oauthSchema,
-  refreshTokenSchema,
   registerSchema,
   resetPasswordRequestSchema,
   resetPasswordSchema,
   verifyEmailRequestSchema,
 } from '../schemas/auth';
 import { emailService } from '../lib/email';
+import { accessTokenCookie, refreshTokenCookie, COOKIE_NAMES } from '../lib/cookie';
 
 const router = Router();
 
@@ -35,6 +35,18 @@ const maskEmail = (value: unknown) => {
 
 const createAccessToken = (user: { id: number; email: string; role: string }) => {
   return auth.generateToken({ userId: user.id, email: user.email, role: user.role }, '15m');
+};
+
+/** Write both auth cookies onto the response. */
+const setAuthCookies = (res: Response, accessToken: string, refreshToken: string) => {
+  res.cookie(COOKIE_NAMES.ACCESS_TOKEN, accessToken, accessTokenCookie());
+  res.cookie(COOKIE_NAMES.REFRESH_TOKEN, refreshToken, refreshTokenCookie());
+};
+
+/** Clear both auth cookies (used on logout and invalid-token paths). */
+const clearAuthCookies = (res: Response) => {
+  res.clearCookie(COOKIE_NAMES.ACCESS_TOKEN, { path: '/' });
+  res.clearCookie(COOKIE_NAMES.REFRESH_TOKEN, { path: '/' });
 };
 
 // POST /api/auth/register
@@ -64,14 +76,9 @@ router.post('/register', validateBody(registerSchema), async (req: Request, res:
     const verification = await userService.createEmailVerificationToken(user.id);
     await emailService.sendVerificationEmail(user.email, verification.token);
 
+    setAuthCookies(res, accessToken, refreshToken.token);
     res.status(201).json({
-      token: accessToken,
-      refreshToken: refreshToken.token,
-      user: {
-        id: user.id,
-        email: user.email,
-        role: user.role,
-      },
+      user: { id: user.id, email: user.email, role: user.role },
     });
   } catch (error) {
     const requestId = (req as Request & { requestId?: string }).requestId;
@@ -101,15 +108,9 @@ router.post('/login', validateBody(loginSchema), async (req: Request, res: Respo
     const accessToken = createAccessToken({ id: user.id, email: user.email, role: user.role });
     const refreshToken = await userService.createRefreshToken(user.id);
 
+    setAuthCookies(res, accessToken, refreshToken.token);
     res.json({
-      token: accessToken,
-      refreshToken: refreshToken.token,
-      user: {
-        id: user.id,
-        email: user.email,
-        role: user.role,
-        isVerified: identity.isVerified,
-      },
+      user: { id: user.id, email: user.email, role: user.role, isVerified: identity.isVerified },
     });
   } catch (error) {
     const requestId = (req as Request & { requestId?: string }).requestId;
@@ -119,25 +120,29 @@ router.post('/login', validateBody(loginSchema), async (req: Request, res: Respo
 });
 
 // POST /api/auth/refresh-token
-router.post('/refresh-token', validateBody(refreshTokenSchema), async (req: Request, res: Response) => {
+// Reads the refresh token from the httpOnly cookie — no body required.
+router.post('/refresh-token', async (req: Request, res: Response) => {
   try {
-    const { refreshToken } = req.body;
+    const refreshToken = req.cookies?.[COOKIE_NAMES.REFRESH_TOKEN];
+    if (!refreshToken) {
+      return res.status(401).json({ message: 'Missing refresh token' });
+    }
+
     const rotated = await userService.rotateRefreshToken(refreshToken);
     if (!rotated) {
+      clearAuthCookies(res);
       return res.status(401).json({ message: 'Invalid refresh token' });
     }
 
     const user = await userService.findUserById(rotated.userId);
     if (!user) {
+      clearAuthCookies(res);
       return res.status(401).json({ message: 'Invalid refresh token' });
     }
 
     const accessToken = createAccessToken({ id: user.id, email: user.email, role: user.role });
-
-    res.json({
-      token: accessToken,
-      refreshToken: rotated.token,
-    });
+    setAuthCookies(res, accessToken, rotated.token);
+    res.json({ user: { id: user.id, email: user.email, role: user.role } });
   } catch (error) {
     const requestId = (req as Request & { requestId?: string }).requestId;
     logger.error('Refresh token failed', { requestId, error });
@@ -146,14 +151,20 @@ router.post('/refresh-token', validateBody(refreshTokenSchema), async (req: Requ
 });
 
 // POST /api/auth/logout
-router.post('/logout', validateBody(refreshTokenSchema), async (req: Request, res: Response) => {
+// Reads the refresh token from the httpOnly cookie to revoke it server-side.
+router.post('/logout', async (req: Request, res: Response) => {
   try {
-    const { refreshToken } = req.body;
-    await userService.revokeRefreshToken(refreshToken);
+    const refreshToken = req.cookies?.[COOKIE_NAMES.REFRESH_TOKEN];
+    if (refreshToken) {
+      await userService.revokeRefreshToken(refreshToken);
+    }
+    clearAuthCookies(res);
     res.json({ success: true });
   } catch (error) {
     const requestId = (req as Request & { requestId?: string }).requestId;
     logger.error('Logout failed', { requestId, error });
+    // Clear cookies even on error so the client is not left in a broken state.
+    clearAuthCookies(res);
     res.status(500).json({ message: 'Logout failed' });
   }
 });
@@ -270,19 +281,40 @@ router.post('/oauth/:provider', validateBody(oauthSchema), async (req: Request, 
     const accessToken = createAccessToken({ id: user.id, email: user.email, role: user.role });
     const refreshToken = await userService.createRefreshToken(user.id);
 
+    setAuthCookies(res, accessToken, refreshToken.token);
     res.json({
-      token: accessToken,
-      refreshToken: refreshToken.token,
-      user: {
-        id: user.id,
-        email: user.email,
-        role: user.role,
-      },
+      user: { id: user.id, email: user.email, role: user.role },
     });
   } catch (error) {
     const requestId = (req as Request & { requestId?: string }).requestId;
     logger.error('Social login failed', { requestId, error });
     res.status(500).json({ message: 'Social login failed' });
+  }
+});
+
+// GET /api/auth/me
+// Cookie-based session bootstrap: verifies the access_token cookie and returns
+// the current user. Called on page load so the frontend can restore auth state
+// without touching localStorage.
+router.get('/me', async (req: Request, res: Response) => {
+  try {
+    const accessToken = req.cookies?.[COOKIE_NAMES.ACCESS_TOKEN];
+    if (!accessToken) {
+      return res.status(401).json({ message: 'Not authenticated' });
+    }
+
+    const decoded = auth.verifyToken(accessToken);
+    const user = await userService.findUserById(decoded.userId);
+    if (!user) {
+      clearAuthCookies(res);
+      return res.status(401).json({ message: 'User not found' });
+    }
+
+    res.json({
+      user: { id: user.id, email: user.email, role: user.role },
+    });
+  } catch {
+    return res.status(401).json({ message: 'Invalid or expired token' });
   }
 });
 

--- a/src/backend/src/api/auth.ts
+++ b/src/backend/src/api/auth.ts
@@ -12,7 +12,7 @@ import {
   verifyEmailRequestSchema,
 } from '../schemas/auth';
 import { emailService } from '../lib/email';
-import { accessTokenCookie, refreshTokenCookie, COOKIE_NAMES } from '../lib/cookie';
+import { accessTokenCookie, baseCookieOptions, refreshTokenCookie, COOKIE_NAMES } from '../lib/cookie';
 
 const router = Router();
 
@@ -45,8 +45,8 @@ const setAuthCookies = (res: Response, accessToken: string, refreshToken: string
 
 /** Clear both auth cookies (used on logout and invalid-token paths). */
 const clearAuthCookies = (res: Response) => {
-  res.clearCookie(COOKIE_NAMES.ACCESS_TOKEN, { path: '/' });
-  res.clearCookie(COOKIE_NAMES.REFRESH_TOKEN, { path: '/' });
+  res.clearCookie(COOKIE_NAMES.ACCESS_TOKEN, baseCookieOptions());
+  res.clearCookie(COOKIE_NAMES.REFRESH_TOKEN, baseCookieOptions());
 };
 
 // POST /api/auth/register

--- a/src/backend/src/api/auth.ts
+++ b/src/backend/src/api/auth.ts
@@ -314,6 +314,7 @@ router.get('/me', async (req: Request, res: Response) => {
       user: { id: user.id, email: user.email, role: user.role },
     });
   } catch {
+    clearAuthCookies(res);
     return res.status(401).json({ message: 'Invalid or expired token' });
   }
 });

--- a/src/backend/src/lib/auth.ts
+++ b/src/backend/src/lib/auth.ts
@@ -1,5 +1,7 @@
 import jwt, { SignOptions } from 'jsonwebtoken';
 import bcrypt from 'bcryptjs';
+import { Request } from 'express';
+import { COOKIE_NAMES } from './cookie';
 
 const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret-do-not-use-in-prod';
 const SALT_ROUNDS = 10;
@@ -61,4 +63,20 @@ export const auth = {
       return null;
     }
   },
+};
+
+/**
+ * Extract the access token from the httpOnly cookie first,
+ * falling back to the Authorization header for backward compatibility.
+ */
+export const extractAccessToken = (req: Request): string | undefined => {
+  const cookieToken = req.cookies?.[COOKIE_NAMES.ACCESS_TOKEN];
+  if (cookieToken) return cookieToken;
+
+  const authHeader = req.headers.authorization;
+  if (authHeader?.startsWith('Bearer ')) {
+    return authHeader.split(' ')[1];
+  }
+
+  return undefined;
 };

--- a/src/backend/src/lib/auth.ts
+++ b/src/backend/src/lib/auth.ts
@@ -75,7 +75,8 @@ export const extractAccessToken = (req: Request): string | undefined => {
 
   const authHeader = req.headers.authorization;
   if (authHeader?.startsWith('Bearer ')) {
-    return authHeader.split(' ')[1];
+    const token = authHeader.split(' ')[1];
+    if (token) return token;
   }
 
   return undefined;

--- a/src/backend/src/middleware/adminAuth.ts
+++ b/src/backend/src/middleware/adminAuth.ts
@@ -1,23 +1,20 @@
 import { Request, Response, NextFunction } from 'express';
-import { auth, TokenPayload } from '../lib/auth';
+import { auth, extractAccessToken, TokenPayload } from '../lib/auth';
 
 export const adminAuth = (req: Request, res: Response, next: NextFunction) => {
-  const authHeader = req.headers.authorization;
+  const token = extractAccessToken(req);
 
-  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+  if (!token) {
     return res.status(401).json({ message: 'Unauthorized: Missing token' });
   }
-
-  const token = authHeader.split(' ')[1];
 
   try {
     const decoded = auth.verifyToken(token);
 
     if (decoded.role !== 'ADMIN') {
-        return res.status(403).json({ message: 'Forbidden: Admin access only' });
+      return res.status(403).json({ message: 'Forbidden: Admin access only' });
     }
 
-    // Attach user to request if needed, though usually handled by general auth middleware
     (req as Request & { user?: TokenPayload }).user = decoded;
     next();
   } catch {

--- a/src/backend/src/middleware/auth.ts
+++ b/src/backend/src/middleware/auth.ts
@@ -1,17 +1,16 @@
 import { Request, Response, NextFunction } from 'express';
-import { auth, TokenPayload } from '../lib/auth';
+import { auth, extractAccessToken, TokenPayload } from '../lib/auth';
 
 export interface AuthRequest extends Request {
   user?: TokenPayload;
 }
 
 export const authenticate = (req: Request, res: Response, next: NextFunction) => {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+  const token = extractAccessToken(req);
+  if (!token) {
     return res.status(401).json({ message: 'Unauthorized' });
   }
 
-  const token = authHeader.split(' ')[1];
   try {
     const decoded = auth.verifyToken(token);
     (req as AuthRequest).user = decoded;

--- a/src/backend/tests/integration/auth.test.ts
+++ b/src/backend/tests/integration/auth.test.ts
@@ -18,7 +18,7 @@ describe('Auth API', () => {
   });
 
   describe('POST /api/auth/register', () => {
-    it('should register a new user', async () => {
+    it('should register a new user and set auth cookies', async () => {
       const res = await request(app)
         .post('/api/auth/register')
         .send({
@@ -27,8 +27,12 @@ describe('Auth API', () => {
         });
 
       expect(res.status).toBe(201);
-      expect(res.body).toHaveProperty('token');
+      // Tokens are now delivered as httpOnly cookies, not in the body.
+      expect(res.body).not.toHaveProperty('token');
       expect(res.body.user).toHaveProperty('email', 'newuser@example.com');
+      const cookies = res.headers['set-cookie'] as unknown as string[];
+      expect(cookies.some((c: string) => c.startsWith('access_token='))).toBe(true);
+      expect(cookies.some((c: string) => c.startsWith('refresh_token='))).toBe(true);
     });
 
     it('should fail if user already exists', async () => {
@@ -60,7 +64,7 @@ describe('Auth API', () => {
         });
     });
 
-    it('should login with correct credentials', async () => {
+    it('should login with correct credentials and set auth cookies', async () => {
       const res = await request(app)
         .post('/api/auth/login')
         .send({
@@ -69,7 +73,12 @@ describe('Auth API', () => {
         });
 
       expect(res.status).toBe(200);
-      expect(res.body).toHaveProperty('token');
+      // Tokens are now delivered as httpOnly cookies, not in the body.
+      expect(res.body).not.toHaveProperty('token');
+      expect(res.body.user).toHaveProperty('email', 'loginuser@example.com');
+      const cookies = res.headers['set-cookie'] as unknown as string[];
+      expect(cookies.some((c: string) => c.startsWith('access_token='))).toBe(true);
+      expect(cookies.some((c: string) => c.startsWith('refresh_token='))).toBe(true);
     });
 
     it('should fail with incorrect password', async () => {

--- a/src/backend/tests/unit/authMiddleware.test.ts
+++ b/src/backend/tests/unit/authMiddleware.test.ts
@@ -1,0 +1,186 @@
+import { authenticate, AuthRequest } from '../../src/middleware/auth';
+import { adminAuth } from '../../src/middleware/adminAuth';
+import { auth } from '../../src/lib/auth';
+import { COOKIE_NAMES } from '../../src/lib/cookie';
+
+const mockReq = (cookies?: Record<string, string>, authHeader?: string) => ({
+  cookies,
+  headers: { authorization: authHeader },
+} as any);
+
+const mockRes = () => {
+  const res: any = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+const mockNext = () => jest.fn();
+
+const validUserToken = auth.generateToken(
+  { userId: 1, email: 'user@test.com', role: 'USER' },
+  '1h'
+);
+const validAdminToken = auth.generateToken(
+  { userId: 2, email: 'admin@test.com', role: 'ADMIN' },
+  '1h'
+);
+
+describe('authenticate middleware', () => {
+  it('should call next() with valid cookie token', () => {
+    const req = mockReq({ [COOKIE_NAMES.ACCESS_TOKEN]: validUserToken });
+    const res = mockRes();
+    const next = mockNext();
+
+    authenticate(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect((req as AuthRequest).user).toBeDefined();
+    expect((req as AuthRequest).user?.userId).toBe(1);
+  });
+
+  it('should call next() with valid Bearer header token', () => {
+    const req = mockReq(undefined, `Bearer ${validUserToken}`);
+    const res = mockRes();
+    const next = mockNext();
+
+    authenticate(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect((req as AuthRequest).user).toBeDefined();
+    expect((req as AuthRequest).user?.email).toBe('user@test.com');
+  });
+
+  it('should return 401 when no token present', () => {
+    const req = mockReq();
+    const res = mockRes();
+    const next = mockNext();
+
+    authenticate(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Unauthorized' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should return 401 for expired/invalid token', () => {
+    const req = mockReq({ [COOKIE_NAMES.ACCESS_TOKEN]: 'invalid-token' });
+    const res = mockRes();
+    const next = mockNext();
+
+    authenticate(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Invalid token' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should set req.user with correct payload', () => {
+    const req = mockReq({ [COOKIE_NAMES.ACCESS_TOKEN]: validUserToken });
+    const res = mockRes();
+    const next = mockNext();
+
+    authenticate(req, res, next);
+
+    expect((req as AuthRequest).user).toBeDefined();
+    expect((req as AuthRequest).user?.userId).toBe(1);
+    expect((req as AuthRequest).user?.email).toBe('user@test.com');
+    expect((req as AuthRequest).user?.role).toBe('USER');
+  });
+
+  it('should prioritize cookie over header', () => {
+    const req = mockReq(
+      { [COOKIE_NAMES.ACCESS_TOKEN]: validAdminToken },
+      `Bearer ${validUserToken}`
+    );
+    const res = mockRes();
+    const next = mockNext();
+
+    authenticate(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect((req as AuthRequest).user?.role).toBe('ADMIN');
+  });
+});
+
+describe('adminAuth middleware', () => {
+  it('should call next() with valid admin cookie token', () => {
+    const req = mockReq({ [COOKIE_NAMES.ACCESS_TOKEN]: validAdminToken });
+    const res = mockRes();
+    const next = mockNext();
+
+    adminAuth(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('should return 403 for non-admin token', () => {
+    const req = mockReq({ [COOKIE_NAMES.ACCESS_TOKEN]: validUserToken });
+    const res = mockRes();
+    const next = mockNext();
+
+    adminAuth(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'Forbidden: Admin access only',
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should return 401 when no token present', () => {
+    const req = mockReq();
+    const res = mockRes();
+    const next = mockNext();
+
+    adminAuth(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'Unauthorized: Missing token',
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should return 401 for invalid token', () => {
+    const req = mockReq({ [COOKIE_NAMES.ACCESS_TOKEN]: 'bad-token' });
+    const res = mockRes();
+    const next = mockNext();
+
+    adminAuth(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'Unauthorized: Invalid token',
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should prioritize cookie over header (admin access granted)', () => {
+    const req = mockReq(
+      { [COOKIE_NAMES.ACCESS_TOKEN]: validAdminToken },
+      `Bearer ${validUserToken}`
+    );
+    const res = mockRes();
+    const next = mockNext();
+
+    adminAuth(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('should set req.user with admin payload', () => {
+    const req = mockReq({ [COOKIE_NAMES.ACCESS_TOKEN]: validAdminToken });
+    const res = mockRes();
+    const next = mockNext();
+
+    adminAuth(req, res, next);
+
+    expect((req as any).user).toBeDefined();
+    expect((req as any).user.userId).toBe(2);
+    expect((req as any).user.email).toBe('admin@test.com');
+    expect((req as any).user.role).toBe('ADMIN');
+  });
+});

--- a/src/backend/tests/unit/extractAccessToken.test.ts
+++ b/src/backend/tests/unit/extractAccessToken.test.ts
@@ -1,0 +1,68 @@
+import { extractAccessToken } from '../../src/lib/auth';
+import { COOKIE_NAMES } from '../../src/lib/cookie';
+
+const mockRequest = (cookies?: Record<string, string>, authHeader?: string) => ({
+  cookies,
+  headers: {
+    authorization: authHeader,
+  },
+} as any);
+
+describe('extractAccessToken', () => {
+  it('should return token from cookie when present', () => {
+    const req = mockRequest({ [COOKIE_NAMES.ACCESS_TOKEN]: 'cookie-token' });
+    const token = extractAccessToken(req);
+    expect(token).toBe('cookie-token');
+  });
+
+  it('should return token from Bearer header when no cookie', () => {
+    const req = mockRequest(undefined, 'Bearer header-token');
+    const token = extractAccessToken(req);
+    expect(token).toBe('header-token');
+  });
+
+  it('should prioritize cookie over Bearer header', () => {
+    const req = mockRequest(
+      { [COOKIE_NAMES.ACCESS_TOKEN]: 'cookie-token' },
+      'Bearer header-token'
+    );
+    const token = extractAccessToken(req);
+    expect(token).toBe('cookie-token');
+  });
+
+  it('should return undefined when neither cookie nor header present', () => {
+    const req = mockRequest();
+    const token = extractAccessToken(req);
+    expect(token).toBeUndefined();
+  });
+
+  it('should return undefined for malformed Bearer header', () => {
+    const req = mockRequest(undefined, 'Basic xyz');
+    const token = extractAccessToken(req);
+    expect(token).toBeUndefined();
+  });
+
+  it('should return undefined when cookies object is undefined', () => {
+    const req = mockRequest(undefined, undefined);
+    const token = extractAccessToken(req);
+    expect(token).toBeUndefined();
+  });
+
+  it('should return empty string for Bearer header with no token', () => {
+    const req = mockRequest(undefined, 'Bearer ');
+    const token = extractAccessToken(req);
+    expect(token).toBe('');
+  });
+
+  it('should return undefined when authorization header is not Bearer', () => {
+    const req = mockRequest(undefined, 'Token abc123');
+    const token = extractAccessToken(req);
+    expect(token).toBeUndefined();
+  });
+
+  it('should handle empty cookies object', () => {
+    const req = mockRequest({}, undefined);
+    const token = extractAccessToken(req);
+    expect(token).toBeUndefined();
+  });
+});

--- a/src/backend/tests/unit/extractAccessToken.test.ts
+++ b/src/backend/tests/unit/extractAccessToken.test.ts
@@ -48,10 +48,10 @@ describe('extractAccessToken', () => {
     expect(token).toBeUndefined();
   });
 
-  it('should return empty string for Bearer header with no token', () => {
+  it('should return undefined for Bearer header with no token', () => {
     const req = mockRequest(undefined, 'Bearer ');
     const token = extractAccessToken(req);
-    expect(token).toBe('');
+    expect(token).toBeUndefined();
   });
 
   it('should return undefined when authorization header is not Bearer', () => {

--- a/src/backend/tests/unit/middleware/adminAuth.test.ts
+++ b/src/backend/tests/unit/middleware/adminAuth.test.ts
@@ -1,17 +1,26 @@
 import { Request, Response, NextFunction } from 'express';
 import { adminAuth } from '../../../src/middleware/adminAuth';
 import { auth } from '../../../src/lib/auth';
-
-jest.mock('../../../src/lib/auth');
+import { COOKIE_NAMES } from '../../../src/lib/cookie';
 
 describe('Admin Auth Middleware', () => {
   let mockRequest: Partial<Request>;
   let mockResponse: Partial<Response>;
   let nextFunction: NextFunction;
 
+  const validAdminToken = auth.generateToken(
+    { userId: 1, email: 'admin@test.com', role: 'ADMIN' },
+    '1h'
+  );
+  const validUserToken = auth.generateToken(
+    { userId: 2, email: 'user@test.com', role: 'USER' },
+    '1h'
+  );
+
   beforeEach(() => {
     mockRequest = {
       headers: {},
+      cookies: {},
     };
     mockResponse = {
       status: jest.fn().mockReturnThis(),
@@ -21,10 +30,9 @@ describe('Admin Auth Middleware', () => {
   });
 
   it('should call next() if token is valid and role is ADMIN', () => {
-    mockRequest.headers = {
-        authorization: 'Bearer valid-admin-token'
+    mockRequest.cookies = {
+      [COOKIE_NAMES.ACCESS_TOKEN]: validAdminToken,
     };
-    (auth.verifyToken as jest.Mock).mockReturnValue({ role: 'ADMIN' });
 
     adminAuth(mockRequest as Request, mockResponse as Response, nextFunction);
 
@@ -40,10 +48,9 @@ describe('Admin Auth Middleware', () => {
   });
 
   it('should return 403 if role is not ADMIN', () => {
-    mockRequest.headers = {
-        authorization: 'Bearer user-token'
+    mockRequest.cookies = {
+      [COOKIE_NAMES.ACCESS_TOKEN]: validUserToken,
     };
-    (auth.verifyToken as jest.Mock).mockReturnValue({ role: 'USER' });
 
     adminAuth(mockRequest as Request, mockResponse as Response, nextFunction);
 
@@ -51,10 +58,9 @@ describe('Admin Auth Middleware', () => {
   });
 
   it('should return 401 if token is invalid', () => {
-    mockRequest.headers = {
-        authorization: 'Bearer invalid-token'
+    mockRequest.cookies = {
+      [COOKIE_NAMES.ACCESS_TOKEN]: 'invalid-token',
     };
-    (auth.verifyToken as jest.Mock).mockImplementation(() => { throw new Error('Invalid token'); });
 
     adminAuth(mockRequest as Request, mockResponse as Response, nextFunction);
 

--- a/src/frontend/src/api/addresses.ts
+++ b/src/frontend/src/api/addresses.ts
@@ -14,11 +14,8 @@ export interface Address {
   isDefault?: boolean;
 }
 
-export const fetchAddresses = async (token: string): Promise<Address[]> => {
+export const fetchAddresses = async (): Promise<Address[]> => {
   const response = await fetch(`${API_BASE_URL}/addresses`, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
     credentials: 'include',
   });
 
@@ -31,12 +28,11 @@ export const fetchAddresses = async (token: string): Promise<Address[]> => {
   return result.data;
 };
 
-export const createAddress = async (payload: Omit<Address, 'id'>, token: string): Promise<Address> => {
+export const createAddress = async (payload: Omit<Address, 'id'>): Promise<Address> => {
   const response = await fetch(`${API_BASE_URL}/addresses`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
     },
     credentials: 'include',
     body: JSON.stringify(payload),

--- a/src/frontend/src/api/admin.ts
+++ b/src/frontend/src/api/admin.ts
@@ -2,10 +2,7 @@ import type { Category, Product, WellbeingTag } from './catalog';
 import { API_BASE_URL } from '../config';
 import type { OrderResponse } from './orders';
 
-const getHeaders = (token: string) => ({
-  'Content-Type': 'application/json',
-  Authorization: `Bearer ${token}`,
-});
+const jsonHeaders = { 'Content-Type': 'application/json' };
 
 export interface PaginatedAdminOrders {
   data: OrderResponse[];
@@ -33,9 +30,8 @@ export interface PaginatedAdminUsers {
   hasNextPage: boolean;
 }
 
-export const fetchAdminProducts = async (token: string, page = 1, limit = 20): Promise<Product[]> => {
+export const fetchAdminProducts = async (page = 1, limit = 20): Promise<Product[]> => {
   const response = await fetch(`${API_BASE_URL}/admin/products?page=${page}&limit=${limit}`, {
-    headers: getHeaders(token),
     credentials: 'include',
   });
   if (!response.ok) throw new Error('Failed to fetch admin products');
@@ -44,12 +40,10 @@ export const fetchAdminProducts = async (token: string, page = 1, limit = 20): P
 };
 
 export const fetchAdminOrders = async (
-  token: string,
   page = 1,
   limit = 20,
 ): Promise<PaginatedAdminOrders> => {
   const response = await fetch(`${API_BASE_URL}/admin/orders?page=${page}&limit=${limit}`, {
-    headers: getHeaders(token),
     credentials: 'include',
   });
   if (!response.ok) throw new Error('Failed to fetch admin orders');
@@ -63,9 +57,8 @@ export const fetchAdminOrders = async (
   };
 };
 
-export const fetchAdminUsers = async (token: string, page = 1, limit = 20): Promise<PaginatedAdminUsers> => {
+export const fetchAdminUsers = async (page = 1, limit = 20): Promise<PaginatedAdminUsers> => {
   const response = await fetch(`${API_BASE_URL}/admin/users?page=${page}&limit=${limit}`, {
-    headers: getHeaders(token),
     credentials: 'include',
   });
   if (!response.ok) throw new Error('Failed to fetch users');
@@ -80,13 +73,12 @@ export const fetchAdminUsers = async (token: string, page = 1, limit = 20): Prom
 };
 
 export const updateAdminUser = async (
-  token: string,
   id: number,
   payload: { role?: AdminUser['role']; isActive?: boolean },
 ): Promise<AdminUser> => {
   const response = await fetch(`${API_BASE_URL}/admin/users/${id}`, {
     method: 'PATCH',
-    headers: getHeaders(token),
+    headers: jsonHeaders,
     credentials: 'include',
     body: JSON.stringify(payload),
   });
@@ -98,9 +90,8 @@ export const updateAdminUser = async (
   return result.data;
 };
 
-export const fetchAdminOrder = async (token: string, id: number): Promise<OrderResponse> => {
+export const fetchAdminOrder = async (id: number): Promise<OrderResponse> => {
   const response = await fetch(`${API_BASE_URL}/admin/orders/${id}`, {
-    headers: getHeaders(token),
     credentials: 'include',
   });
   if (!response.ok) {
@@ -111,10 +102,10 @@ export const fetchAdminOrder = async (token: string, id: number): Promise<OrderR
   return result.data;
 };
 
-export const updateOrderStatus = async (token: string, id: number, status: string): Promise<OrderResponse> => {
+export const updateOrderStatus = async (id: number, status: string): Promise<OrderResponse> => {
     const response = await fetch(`${API_BASE_URL}/admin/orders/${id}/status`, {
         method: 'PATCH',
-        headers: getHeaders(token),
+        headers: jsonHeaders,
         credentials: 'include',
         body: JSON.stringify({ status })
     });
@@ -125,10 +116,10 @@ export const updateOrderStatus = async (token: string, id: number, status: strin
 
 export type AdminProductPayload = Partial<Product> & Record<string, unknown>;
 
-export const createProduct = async (token: string, productData: AdminProductPayload): Promise<Product> => {
+export const createProduct = async (productData: AdminProductPayload): Promise<Product> => {
     const response = await fetch(`${API_BASE_URL}/admin/products`, {
         method: 'POST',
-        headers: getHeaders(token),
+        headers: jsonHeaders,
         credentials: 'include',
         body: JSON.stringify(productData)
     });
@@ -136,10 +127,10 @@ export const createProduct = async (token: string, productData: AdminProductPayl
     return response.json();
 };
 
-export const updateProduct = async (token: string, id: number, productData: AdminProductPayload): Promise<Product> => {
+export const updateProduct = async (id: number, productData: AdminProductPayload): Promise<Product> => {
     const response = await fetch(`${API_BASE_URL}/admin/products/${id}`, {
         method: 'PUT',
-        headers: getHeaders(token),
+        headers: jsonHeaders,
         credentials: 'include',
         body: JSON.stringify(productData)
     });
@@ -147,22 +138,20 @@ export const updateProduct = async (token: string, id: number, productData: Admi
     return response.json();
 };
 
-export const deleteProduct = async (token: string, id: number): Promise<void> => {
+export const deleteProduct = async (id: number): Promise<void> => {
   const response = await fetch(`${API_BASE_URL}/admin/products/${id}`, {
     method: 'DELETE',
-    headers: getHeaders(token),
     credentials: 'include',
   });
   if (!response.ok) throw new Error('Failed to delete product');
 };
 
 export const createCategory = async (
-  token: string,
   payload: { name: string; description?: string; parentId?: number | null },
 ): Promise<Category> => {
   const response = await fetch(`${API_BASE_URL}/admin/catalog/categories`, {
     method: 'POST',
-    headers: getHeaders(token),
+    headers: jsonHeaders,
     credentials: 'include',
     body: JSON.stringify(payload),
   });
@@ -175,13 +164,12 @@ export const createCategory = async (
 };
 
 export const updateCategory = async (
-  token: string,
   id: number,
   payload: { name?: string; description?: string; parentId?: number | null },
 ): Promise<Category> => {
   const response = await fetch(`${API_BASE_URL}/admin/catalog/categories/${id}`, {
     method: 'PUT',
-    headers: getHeaders(token),
+    headers: jsonHeaders,
     credentials: 'include',
     body: JSON.stringify(payload),
   });
@@ -193,10 +181,9 @@ export const updateCategory = async (
   return result.data;
 };
 
-export const deleteCategory = async (token: string, id: number): Promise<void> => {
+export const deleteCategory = async (id: number): Promise<void> => {
   const response = await fetch(`${API_BASE_URL}/admin/catalog/categories/${id}`, {
     method: 'DELETE',
-    headers: getHeaders(token),
     credentials: 'include',
   });
   if (!response.ok) {
@@ -206,12 +193,11 @@ export const deleteCategory = async (token: string, id: number): Promise<void> =
 };
 
 export const createTag = async (
-  token: string,
   payload: { name: string; type: WellbeingTag['type'] },
 ): Promise<WellbeingTag> => {
   const response = await fetch(`${API_BASE_URL}/admin/catalog/tags`, {
     method: 'POST',
-    headers: getHeaders(token),
+    headers: jsonHeaders,
     credentials: 'include',
     body: JSON.stringify(payload),
   });
@@ -224,13 +210,12 @@ export const createTag = async (
 };
 
 export const updateTag = async (
-  token: string,
   id: number,
   payload: { name?: string; type?: WellbeingTag['type'] },
 ): Promise<WellbeingTag> => {
   const response = await fetch(`${API_BASE_URL}/admin/catalog/tags/${id}`, {
     method: 'PUT',
-    headers: getHeaders(token),
+    headers: jsonHeaders,
     credentials: 'include',
     body: JSON.stringify(payload),
   });
@@ -242,10 +227,9 @@ export const updateTag = async (
   return result.data;
 };
 
-export const deleteTag = async (token: string, id: number): Promise<void> => {
+export const deleteTag = async (id: number): Promise<void> => {
   const response = await fetch(`${API_BASE_URL}/admin/catalog/tags/${id}`, {
     method: 'DELETE',
-    headers: getHeaders(token),
     credentials: 'include',
   });
   if (!response.ok) {

--- a/src/frontend/src/api/auth.ts
+++ b/src/frontend/src/api/auth.ts
@@ -148,15 +148,17 @@ export const authApi = {
   },
 
   async fetchMe(): Promise<{ user: User } | null> {
-    try {
-      const res = await fetch(`${API_BASE_URL}/auth/me`, {
-        credentials: 'include',
-      });
-      if (!res.ok) return null;
-      return res.json();
-    } catch {
+    const res = await fetch(`${API_BASE_URL}/auth/me`, {
+      credentials: 'include',
+    });
+    if (res.status === 401 || res.status === 403) {
       return null;
     }
+    if (!res.ok) {
+      const error = await res.json().catch(() => null);
+      throw new Error(error?.message || 'Failed to fetch current session');
+    }
+    return res.json();
   },
 
   async logout(): Promise<void> {

--- a/src/frontend/src/api/auth.ts
+++ b/src/frontend/src/api/auth.ts
@@ -21,8 +21,6 @@ export interface ProfileResponse {
 }
 
 export interface AuthResponse {
-  token: string;
-  refreshToken?: string;
   user: User;
 }
 
@@ -55,11 +53,8 @@ export const authApi = {
     return res.json();
   },
 
-  async fetchProfile(token: string): Promise<ProfileResponse> {
+  async fetchProfile(): Promise<ProfileResponse> {
     const res = await fetch(`${API_BASE_URL}/me`, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
       credentials: 'include',
     });
     if (!res.ok) {
@@ -71,14 +66,12 @@ export const authApi = {
   },
 
   async updateProfile(
-    token: string,
     data: { firstName?: string; lastName?: string; phone?: string },
   ): Promise<ProfileResponse> {
     const res = await fetch(`${API_BASE_URL}/me`, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
       },
       credentials: 'include',
       body: JSON.stringify(data),
@@ -91,12 +84,11 @@ export const authApi = {
     return result.data;
   },
 
-  async changePassword(token: string, currentPassword: string, password: string): Promise<void> {
+  async changePassword(currentPassword: string, password: string): Promise<void> {
     const res = await fetch(`${API_BASE_URL}/me/password`, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
       },
       credentials: 'include',
       body: JSON.stringify({ currentPassword, password }),
@@ -143,12 +135,10 @@ export const authApi = {
     }
   },
 
-  async refreshToken(refreshToken: string): Promise<{ token: string; refreshToken: string }> {
+  async refreshToken(): Promise<{ user: User }> {
     const res = await fetch(`${API_BASE_URL}/auth/refresh-token`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
-      body: JSON.stringify({ refreshToken }),
     });
     if (!res.ok) {
       const error = await res.json().catch(() => null);

--- a/src/frontend/src/api/auth.ts
+++ b/src/frontend/src/api/auth.ts
@@ -146,4 +146,27 @@ export const authApi = {
     }
     return res.json();
   },
+
+  async fetchMe(): Promise<{ user: User } | null> {
+    try {
+      const res = await fetch(`${API_BASE_URL}/auth/me`, {
+        credentials: 'include',
+      });
+      if (!res.ok) return null;
+      return res.json();
+    } catch {
+      return null;
+    }
+  },
+
+  async logout(): Promise<void> {
+    const res = await fetch(`${API_BASE_URL}/auth/logout`, {
+      method: 'POST',
+      credentials: 'include',
+    });
+    if (!res.ok) {
+      const error = await res.json().catch(() => null);
+      throw new Error(error?.message || 'Logout failed');
+    }
+  },
 };

--- a/src/frontend/src/api/orders.ts
+++ b/src/frontend/src/api/orders.ts
@@ -83,17 +83,12 @@ export interface OrderResponse {
   statusHistory?: OrderStatusHistory[];
 }
 
-export const createOrder = async (payload: OrderPayload, token?: string): Promise<OrderResponse> => {
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-  };
-  if (token) {
-    headers['Authorization'] = `Bearer ${token}`;
-  }
-
+export const createOrder = async (payload: OrderPayload): Promise<OrderResponse> => {
   const response = await fetch(`${API_BASE_URL}/orders`, {
     method: 'POST',
-    headers,
+    headers: {
+      'Content-Type': 'application/json',
+    },
     credentials: 'include',
     body: JSON.stringify(payload),
   });
@@ -115,11 +110,8 @@ export interface PaginatedOrders {
   hasNextPage: boolean;
 }
 
-export const fetchMyOrders = async (token: string, page = 1, limit = 6): Promise<PaginatedOrders> => {
+export const fetchMyOrders = async (page = 1, limit = 6): Promise<PaginatedOrders> => {
   const response = await fetch(`${API_BASE_URL}/orders?page=${page}&limit=${limit}`, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
     credentials: 'include',
   });
 
@@ -137,12 +129,9 @@ export const fetchMyOrders = async (token: string, page = 1, limit = 6): Promise
   };
 };
 
-export const cancelOrder = async (orderId: number, token: string): Promise<OrderResponse> => {
+export const cancelOrder = async (orderId: number): Promise<OrderResponse> => {
   const response = await fetch(`${API_BASE_URL}/orders/${orderId}/cancel`, {
     method: 'POST',
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
     credentials: 'include',
   });
 
@@ -157,18 +146,10 @@ export const cancelOrder = async (orderId: number, token: string): Promise<Order
 
 export const fetchOrder = async (
   id: number,
-  token?: string,
   guestEmail?: string,
 ): Promise<OrderResponse> => {
-  const headers: Record<string, string> = {};
-
-  if (token) {
-    headers.Authorization = `Bearer ${token}`;
-  }
-
   const query = guestEmail ? `?guestEmail=${encodeURIComponent(guestEmail)}` : '';
   const response = await fetch(`${API_BASE_URL}/orders/${id}${query}`, {
-    headers,
     credentials: 'include',
   });
 

--- a/src/frontend/src/components/admin/OrderList.tsx
+++ b/src/frontend/src/components/admin/OrderList.tsx
@@ -16,16 +16,23 @@ export const OrderList: React.FC = () => {
   const { user } = useAuth();
 
   useEffect(() => {
-    if (user) {
-      setLoading(true);
-      fetchAdminOrders(page, 10)
-        .then((result) => {
-          setOrders(result.data);
-          setHasNextPage(result.hasNextPage);
-        })
-        .catch((err) => setError(err.message))
-        .finally(() => setLoading(false));
+    if (!user) {
+      setOrders([]);
+      setHasNextPage(false);
+      setError(null);
+      setLoading(false);
+      return;
     }
+
+    setLoading(true);
+    setError(null);
+    fetchAdminOrders(page, 10)
+      .then((result) => {
+        setOrders(result.data);
+        setHasNextPage(result.hasNextPage);
+      })
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
   }, [user, page]);
 
   const handleStatusChange = async (orderId: number, newStatus: string) => {

--- a/src/frontend/src/components/admin/OrderList.tsx
+++ b/src/frontend/src/components/admin/OrderList.tsx
@@ -13,12 +13,12 @@ export const OrderList: React.FC = () => {
   const [statusFilter, setStatusFilter] = useState('ALL');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const { token } = useAuth();
+  const { user } = useAuth();
 
   useEffect(() => {
-    if (token) {
+    if (user) {
       setLoading(true);
-      fetchAdminOrders(token, page, 10)
+      fetchAdminOrders(page, 10)
         .then((result) => {
           setOrders(result.data);
           setHasNextPage(result.hasNextPage);
@@ -26,12 +26,12 @@ export const OrderList: React.FC = () => {
         .catch((err) => setError(err.message))
         .finally(() => setLoading(false));
     }
-  }, [token, page]);
+  }, [user, page]);
 
   const handleStatusChange = async (orderId: number, newStatus: string) => {
-    if (!token) return;
+    if (!user) return;
     try {
-      const updatedOrder = await updateOrderStatus(token, orderId, newStatus);
+      const updatedOrder = await updateOrderStatus(orderId, newStatus);
       setOrders(orders.map((order) => (order.id === orderId ? updatedOrder : order)));
     } catch {
       alert('Failed to update status');

--- a/src/frontend/src/components/admin/ProductForm.tsx
+++ b/src/frontend/src/components/admin/ProductForm.tsx
@@ -10,7 +10,7 @@ interface ProductFormProps {
 }
 
 export const ProductForm: React.FC<ProductFormProps> = ({ initialData, onSave, onCancel }) => {
-  const { token } = useAuth();
+  const { user } = useAuth();
   const [formData, setFormData] = useState({
     name: '',
     description: '',
@@ -58,7 +58,7 @@ export const ProductForm: React.FC<ProductFormProps> = ({ initialData, onSave, o
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!token) return;
+    if (!user) return;
     setLoading(true);
 
     const payload = {
@@ -72,9 +72,9 @@ export const ProductForm: React.FC<ProductFormProps> = ({ initialData, onSave, o
 
     try {
         if (initialData) {
-            await updateProduct(token, initialData.id, payload);
+            await updateProduct(initialData.id, payload);
         } else {
-            await createProduct(token, payload);
+            await createProduct(payload);
         }
         onSave();
     } catch (err) {

--- a/src/frontend/src/components/admin/ProductList.tsx
+++ b/src/frontend/src/components/admin/ProductList.tsx
@@ -12,14 +12,14 @@ export const ProductList: React.FC<ProductListProps> = ({ onEdit }) => {
   const [products, setProducts] = useState<Product[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const { token } = useAuth();
+  const { user } = useAuth();
 
   const loadProducts = async () => {
-    if (!token) return;
+    if (!user) return;
     setLoading(true);
     setError(null);
     try {
-      const data = await fetchAdminProducts(token);
+      const data = await fetchAdminProducts();
       setProducts(data);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Failed to load products';
@@ -31,13 +31,13 @@ export const ProductList: React.FC<ProductListProps> = ({ onEdit }) => {
 
   useEffect(() => {
     loadProducts();
-  }, [token]);
+  }, [user]);
 
   const handleDelete = async (id: number) => {
-    if (!token) return;
+    if (!user) return;
     if (!confirm('Are you sure you want to delete this product?')) return;
     try {
-      await deleteProduct(token, id);
+      await deleteProduct(id);
       setProducts(products.filter(p => p.id !== id));
     } catch {
       alert('Failed to delete product');
@@ -45,11 +45,11 @@ export const ProductList: React.FC<ProductListProps> = ({ onEdit }) => {
   };
 
   const toggleStock = async (product: Product) => {
-    if (!token) return;
+    if (!user) return;
     const newQty = product.stockQuantity > 0 ? 0 : 10;
 
     try {
-      const updated = await updateProduct(token, product.id, { stockQuantity: newQty });
+      const updated = await updateProduct(product.id, { stockQuantity: newQty });
       setProducts(products.map((p) => (p.id === product.id ? updated : p)));
     } catch {
       alert('Failed to update stock status');
@@ -57,9 +57,9 @@ export const ProductList: React.FC<ProductListProps> = ({ onEdit }) => {
   };
 
   const toggleVisibility = async (product: Product) => {
-      if (!token) return;
+      if (!user) return;
       try {
-          const updated = await updateProduct(token, product.id, { isVisible: !product.isVisible });
+          const updated = await updateProduct(product.id, { isVisible: !product.isVisible });
           setProducts(products.map(p => p.id === product.id ? updated : p));
       } catch {
           alert('Failed to update visibility');

--- a/src/frontend/src/components/admin/ProductList.tsx
+++ b/src/frontend/src/components/admin/ProductList.tsx
@@ -15,7 +15,12 @@ export const ProductList: React.FC<ProductListProps> = ({ onEdit }) => {
   const { user } = useAuth();
 
   const loadProducts = async () => {
-    if (!user) return;
+    if (!user) {
+      setProducts([]);
+      setError(null);
+      setLoading(false);
+      return;
+    }
     setLoading(true);
     setError(null);
     try {

--- a/src/frontend/src/context/AuthContext.tsx
+++ b/src/frontend/src/context/AuthContext.tsx
@@ -3,61 +3,42 @@ import { authApi, type AuthResponse, type User } from '../api/auth';
 import { getErrorMessage } from '../utils/error';
 import { AuthContext } from './AuthContextDefinition';
 
-export const AuthProvider = ({ children }: { children: ReactNode }) => {
-  const [token, setToken] = useState<string | null>(localStorage.getItem('token'));
-  const [refreshToken, setRefreshToken] = useState<string | null>(localStorage.getItem('refreshToken'));
-  const [user, setUser] = useState<User | null>(() => {
-    const storedUser = localStorage.getItem('user');
-    if (storedUser) {
-      try {
-        return JSON.parse(storedUser);
-      } catch {
-        return null;
-      }
-    }
+const loadStoredUser = (): User | null => {
+  try {
+    const raw = localStorage.getItem('user');
+    return raw ? JSON.parse(raw) : null;
+  } catch {
     return null;
-  });
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+  }
+};
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [user, setUser] = useState<User | null>(loadStoredUser);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
 
+  // On mount, verify the cookie session is still valid
   useEffect(() => {
-    if (!token && refreshToken) {
-      authApi
-        .refreshToken(refreshToken)
-        .then((data) => {
-          setToken(data.token);
-          setRefreshToken(data.refreshToken);
-          localStorage.setItem('token', data.token);
-          localStorage.setItem('refreshToken', data.refreshToken);
-        })
-        .catch(() => {
-          setToken(null);
-          setUser(null);
-          setRefreshToken(null);
-          localStorage.removeItem('user');
-          localStorage.removeItem('token');
-          localStorage.removeItem('refreshToken');
-        });
-      return;
-    }
+    let cancelled = false;
 
-    if (!token) {
-      setUser(null);
-      localStorage.removeItem('user');
-      localStorage.removeItem('token');
-    }
-  }, [token, refreshToken]);
+    authApi.fetchMe().then((result) => {
+      if (cancelled) return;
+      if (result?.user) {
+        setUser(result.user);
+        localStorage.setItem('user', JSON.stringify(result.user));
+      } else {
+        setUser(null);
+        localStorage.removeItem('user');
+      }
+      setIsLoading(false);
+    });
 
-  const setAuthData = (data: AuthResponse) => {
-    setToken(data.token);
+    return () => { cancelled = true; };
+  }, []);
+
+  const setAuthUser = (data: AuthResponse) => {
     setUser(data.user);
-    localStorage.setItem('token', data.token);
     localStorage.setItem('user', JSON.stringify(data.user));
-
-    if (data.refreshToken) {
-      setRefreshToken(data.refreshToken);
-      localStorage.setItem('refreshToken', data.refreshToken);
-    }
   };
 
   const login = async (email: string, password: string) => {
@@ -65,7 +46,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     setError(null);
     try {
       const data = await authApi.login(email, password);
-      setAuthData(data);
+      setAuthUser(data);
     } catch (err: unknown) {
       const message = getErrorMessage(err);
       setError(message);
@@ -80,7 +61,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     setError(null);
     try {
       const data = await authApi.register(email, password);
-      setAuthData(data);
+      setAuthUser(data);
     } catch (err: unknown) {
       const message = getErrorMessage(err);
       setError(message);
@@ -90,13 +71,14 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     }
   };
 
-  const logout = () => {
-    setToken(null);
+  const logout = async () => {
+    try {
+      await authApi.logout();
+    } catch {
+      // Clear local state even if the server call fails
+    }
     setUser(null);
-    setRefreshToken(null);
-    localStorage.removeItem('token');
     localStorage.removeItem('user');
-    localStorage.removeItem('refreshToken');
   };
 
   const updateUser = useCallback((nextUser: User) => {
@@ -106,7 +88,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
   return (
     <AuthContext.Provider
-      value={{ user, token, isAuthenticated: !!token, login, register, logout, updateUser, isLoading, error }}
+      value={{ user, isAuthenticated: !!user, login, register, logout, updateUser, isLoading, error }}
     >
       {children}
     </AuthContext.Provider>

--- a/src/frontend/src/context/AuthContext.tsx
+++ b/src/frontend/src/context/AuthContext.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, useEffect, type ReactNode } from 'react';
+import { useCallback, useState, useEffect, useRef, type ReactNode } from 'react';
 import { authApi, type AuthResponse, type User } from '../api/auth';
 import { getErrorMessage } from '../utils/error';
 import { AuthContext } from './AuthContextDefinition';
@@ -16,27 +16,37 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const [user, setUser] = useState<User | null>(loadStoredUser);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
+  const authVersionRef = useRef(0);
 
   // On mount, verify the cookie session is still valid
   useEffect(() => {
     let cancelled = false;
+    const requestVersion = authVersionRef.current;
 
-    authApi.fetchMe().then((result) => {
-      if (cancelled) return;
-      if (result?.user) {
-        setUser(result.user);
-        localStorage.setItem('user', JSON.stringify(result.user));
-      } else {
-        setUser(null);
-        localStorage.removeItem('user');
-      }
-      setIsLoading(false);
-    });
+    authApi.fetchMe()
+      .then((result) => {
+        if (cancelled || requestVersion !== authVersionRef.current) return;
+        if (result?.user) {
+          setUser(result.user);
+          localStorage.setItem('user', JSON.stringify(result.user));
+        } else {
+          setUser(null);
+          localStorage.removeItem('user');
+        }
+        setIsLoading(false);
+      })
+      .catch(() => {
+        if (cancelled || requestVersion !== authVersionRef.current) return;
+        // On network/server error, keep the stored user (optimistic)
+        // but mark loading as done so the UI isn't stuck
+        setIsLoading(false);
+      });
 
     return () => { cancelled = true; };
   }, []);
 
   const setAuthUser = (data: AuthResponse) => {
+    authVersionRef.current += 1;
     setUser(data.user);
     localStorage.setItem('user', JSON.stringify(data.user));
   };
@@ -72,6 +82,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   };
 
   const logout = async () => {
+    authVersionRef.current += 1;
     try {
       await authApi.logout();
     } catch {

--- a/src/frontend/src/context/AuthContextDefinition.ts
+++ b/src/frontend/src/context/AuthContextDefinition.ts
@@ -3,11 +3,10 @@ import { type User } from '../api/auth';
 
 export interface AuthContextType {
   user: User | null;
-  token: string | null;
   isAuthenticated: boolean;
   login: (email: string, password: string) => Promise<void>;
   register: (email: string, password: string) => Promise<void>;
-  logout: () => void;
+  logout: () => Promise<void>;
   updateUser: (user: User) => void;
   isLoading: boolean;
   error: string | null;

--- a/src/frontend/src/pages/Checkout.tsx
+++ b/src/frontend/src/pages/Checkout.tsx
@@ -11,7 +11,7 @@ import { useAuth } from '../hooks/useAuth';
 export const Checkout: React.FC = () => {
   const navigate = useNavigate();
   const { items, subtotal, clearCart } = useCart();
-  const { user, token, logout } = useAuth();
+  const { user, logout } = useAuth();
   const [guestEmail, setGuestEmail] = useState(user?.email || '');
   const [paymentPlaceholder, setPaymentPlaceholder] = useState('');
   const [disclaimerAccepted, setDisclaimerAccepted] = useState(false);
@@ -41,10 +41,10 @@ export const Checkout: React.FC = () => {
   }, [user]);
 
   useEffect(() => {
-    if (!token) return;
+    if (!user) return;
     const loadAddresses = async () => {
       try {
-        const data = await fetchAddresses(token);
+        const data = await fetchAddresses();
 
         setSavedAddresses(data);
         if (data.length > 0) {
@@ -65,7 +65,7 @@ export const Checkout: React.FC = () => {
       }
     };
     loadAddresses();
-  }, [token, logout]);
+  }, [user, logout]);
 
   const handleAddressChange = (field: keyof ShippingAddressPayload, value: string) => {
     setAddressForm((prev) => ({
@@ -149,7 +149,7 @@ export const Checkout: React.FC = () => {
       let addressId: number | undefined;
       let shippingAddress: ShippingAddressPayload | undefined;
 
-      if (user && token && typeof selectedAddressId === 'number') {
+      if (user && typeof selectedAddressId === 'number') {
         // Auth user selected a saved address — pass the id directly
         addressId = selectedAddressId;
       } else {
@@ -164,35 +164,31 @@ export const Checkout: React.FC = () => {
           userId: user?.id,
           email: guestEmail,
           userType: user ? 'USER' : 'GUEST',
-          hasToken: !!token,
           addressId,
           hasShippingAddress: !!shippingAddress,
         });
       }
 
-      const order = await createOrder(
-        {
-          // Always send the email shown in the form and the user_type so the
-          // backend can resolve guestEmail correctly without guessing from the
-          // JWT alone. For authenticated orders the backend uses JWT userId and
-          // ignores the email; for guest orders it becomes the guestEmail.
-          email: guestEmail,
-          user_type: user ? 'USER' : 'GUEST',
-          items: items.map((item) => ({
-            product_id: item.product.id,
-            product_variant_id: item.variant?.id,
-            quantity: item.quantity,
-          })),
-          shipping_address: shippingAddress,
-          address_id: addressId,
-          payment_placeholder: paymentPlaceholder,
-          disclaimer_accepted: disclaimerAccepted,
-        },
-        token || undefined,
-      );
+      const order = await createOrder({
+        // Always send the email shown in the form and the user_type so the
+        // backend can resolve guestEmail correctly without guessing from the
+        // JWT alone. For authenticated orders the backend uses JWT userId and
+        // ignores the email; for guest orders it becomes the guestEmail.
+        email: guestEmail,
+        user_type: user ? 'USER' : 'GUEST',
+        items: items.map((item) => ({
+          product_id: item.product.id,
+          product_variant_id: item.variant?.id,
+          quantity: item.quantity,
+        })),
+        shipping_address: shippingAddress,
+        address_id: addressId,
+        payment_placeholder: paymentPlaceholder,
+        disclaimer_accepted: disclaimerAccepted,
+      });
 
       clearCart();
-      const guestQuery = token ? '' : `?guestEmail=${encodeURIComponent(guestEmail)}`;
+      const guestQuery = user ? '' : `?guestEmail=${encodeURIComponent(guestEmail)}`;
       navigate(`/order-confirmation/${order.id}${guestQuery}`, { state: { order } });
     } catch (err) {
       if (import.meta.env.DEV) {

--- a/src/frontend/src/pages/OrderConfirmation.tsx
+++ b/src/frontend/src/pages/OrderConfirmation.tsx
@@ -7,7 +7,7 @@ export const OrderConfirmation: React.FC = () => {
   const location = useLocation();
   const { orderId } = useParams<{ orderId: string }>();
   const [searchParams] = useSearchParams();
-  const { user } = useAuth();
+  const { user, isLoading: authLoading } = useAuth();
   const stateOrder = (location.state as { order?: OrderResponse } | null)?.order;
   const guestEmail = searchParams.get('guestEmail')?.toLowerCase();
 
@@ -18,6 +18,10 @@ export const OrderConfirmation: React.FC = () => {
   useEffect(() => {
     if (!orderId || stateOrder) {
       setLoading(false);
+      return;
+    }
+
+    if (authLoading) {
       return;
     }
 
@@ -45,7 +49,7 @@ export const OrderConfirmation: React.FC = () => {
         setError('Failed to load order details. Please try again.');
       })
       .finally(() => setLoading(false));
-  }, [orderId, stateOrder, user, guestEmail]);
+  }, [orderId, stateOrder, user, authLoading, guestEmail]);
 
   if (loading) {
     return (

--- a/src/frontend/src/pages/OrderConfirmation.tsx
+++ b/src/frontend/src/pages/OrderConfirmation.tsx
@@ -7,7 +7,7 @@ export const OrderConfirmation: React.FC = () => {
   const location = useLocation();
   const { orderId } = useParams<{ orderId: string }>();
   const [searchParams] = useSearchParams();
-  const { token } = useAuth();
+  const { user } = useAuth();
   const stateOrder = (location.state as { order?: OrderResponse } | null)?.order;
   const guestEmail = searchParams.get('guestEmail')?.toLowerCase();
 
@@ -21,7 +21,7 @@ export const OrderConfirmation: React.FC = () => {
       return;
     }
 
-    if (!token && !guestEmail) {
+    if (!user && !guestEmail) {
       setError('Please sign in or provide the guest email to view this order.');
       setLoading(false);
       return;
@@ -35,7 +35,7 @@ export const OrderConfirmation: React.FC = () => {
     }
 
     setLoading(true);
-    fetchOrder(parsedId, token || undefined, guestEmail || undefined)
+    fetchOrder(parsedId, guestEmail || undefined)
       .then((data) => {
         setOrder(data);
         setError(null);
@@ -45,7 +45,7 @@ export const OrderConfirmation: React.FC = () => {
         setError('Failed to load order details. Please try again.');
       })
       .finally(() => setLoading(false));
-  }, [orderId, stateOrder, token, guestEmail]);
+  }, [orderId, stateOrder, user, guestEmail]);
 
   if (loading) {
     return (

--- a/src/frontend/src/pages/OrderDetail.tsx
+++ b/src/frontend/src/pages/OrderDetail.tsx
@@ -32,6 +32,9 @@ export const OrderDetail: React.FC = () => {
 
   useEffect(() => {
     if (!user) {
+      setOrder(null);
+      setCancelMessage(null);
+      setCancelError(null);
       setError('Please sign in to view your order.');
       setLoading(false);
       return;

--- a/src/frontend/src/pages/OrderDetail.tsx
+++ b/src/frontend/src/pages/OrderDetail.tsx
@@ -7,7 +7,7 @@ const cancellableStatuses = ['PENDING', 'PAID'];
 
 export const OrderDetail: React.FC = () => {
   const { id } = useParams<{ id: string }>();
-  const { token } = useAuth();
+  const { user } = useAuth();
   const [order, setOrder] = useState<OrderResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -16,11 +16,11 @@ export const OrderDetail: React.FC = () => {
   const [isCancelling, setIsCancelling] = useState(false);
 
   const loadOrder = async (orderId: number) => {
-    if (!token) return;
+    if (!user) return;
     setLoading(true);
     setError(null);
     try {
-      const data = await fetchOrder(orderId, token);
+      const data = await fetchOrder(orderId);
       setOrder(data);
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to load order.';
@@ -31,7 +31,7 @@ export const OrderDetail: React.FC = () => {
   };
 
   useEffect(() => {
-    if (!token) {
+    if (!user) {
       setError('Please sign in to view your order.');
       setLoading(false);
       return;
@@ -45,16 +45,16 @@ export const OrderDetail: React.FC = () => {
     }
 
     loadOrder(parsedId);
-  }, [id, token]);
+  }, [id, user]);
 
   const handleCancel = async () => {
-    if (!token || !order) return;
+    if (!user || !order) return;
     setCancelMessage(null);
     setCancelError(null);
     setIsCancelling(true);
 
     try {
-      const updated = await cancelOrder(order.id, token);
+      const updated = await cancelOrder(order.id);
       setOrder(updated);
       setCancelMessage('Order cancelled successfully.');
     } catch (err) {

--- a/src/frontend/src/pages/Profile.tsx
+++ b/src/frontend/src/pages/Profile.tsx
@@ -10,7 +10,7 @@ const tabs = ['overview', 'orders', 'addresses', 'security'] as const;
 type TabKey = typeof tabs[number];
 
 export const Profile = () => {
-  const { user, token, updateUser } = useAuth();
+  const { user, updateUser } = useAuth();
   const [activeTab, setActiveTab] = useState<TabKey>('overview');
   const [orders, setOrders] = useState<OrderResponse[]>([]);
   const [ordersPage, setOrdersPage] = useState(1);
@@ -31,10 +31,10 @@ export const Profile = () => {
   const [passwordError, setPasswordError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!token) return;
+    if (!user) return;
     const loadProfile = async () => {
       try {
-        const profile = await authApi.fetchProfile(token);
+        const profile = await authApi.fetchProfile();
         updateUser({
           id: profile.id,
           email: profile.email,
@@ -55,13 +55,13 @@ export const Profile = () => {
     };
 
     loadProfile();
-  }, [token, updateUser]);
+  }, [user, updateUser]);
 
   useEffect(() => {
-    if (!token || activeTab !== 'addresses') return;
+    if (!user || activeTab !== 'addresses') return;
     const loadAddresses = async () => {
       try {
-        const data = await fetchAddresses(token);
+        const data = await fetchAddresses();
         setAddresses(data);
       } catch (err) {
         console.error('Failed to load addresses', err);
@@ -69,15 +69,15 @@ export const Profile = () => {
     };
 
     loadAddresses();
-  }, [token, activeTab]);
+  }, [user, activeTab]);
 
   useEffect(() => {
-    if (!token || activeTab !== 'orders') return;
+    if (!user || activeTab !== 'orders') return;
     const loadOrders = async () => {
       setOrdersLoading(true);
       setOrdersError(null);
       try {
-        const result = await fetchMyOrders(token, ordersPage, 6);
+        const result = await fetchMyOrders(ordersPage, 6);
         setOrders(result.data);
         setOrdersHasNext(result.hasNextPage);
       } catch (err) {
@@ -89,16 +89,16 @@ export const Profile = () => {
     };
 
     loadOrders();
-  }, [token, activeTab, ordersPage]);
+  }, [user, activeTab, ordersPage]);
 
   const handleUpdateProfile = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!token) return;
+    if (!user) return;
     setProfileMessage(null);
     setProfileError(null);
 
     try {
-      const updated = await authApi.updateProfile(token, profileForm);
+      const updated = await authApi.updateProfile(profileForm);
       updateUser({
         id: updated.id,
         email: updated.email,
@@ -121,7 +121,7 @@ export const Profile = () => {
     setPasswordMessage(null);
     setPasswordError(null);
 
-    if (!token) return;
+    if (!user) return;
     if (!passwordForm.currentPassword) {
       setPasswordError('Current password is required.');
       return;
@@ -136,7 +136,7 @@ export const Profile = () => {
     }
 
     try {
-      await authApi.changePassword(token, passwordForm.currentPassword, passwordForm.password);
+      await authApi.changePassword(passwordForm.currentPassword, passwordForm.password);
       setPasswordMessage('Password updated successfully.');
       setPasswordForm({ currentPassword: '', password: '', confirm: '' });
     } catch (err) {

--- a/src/frontend/src/pages/Profile.tsx
+++ b/src/frontend/src/pages/Profile.tsx
@@ -31,7 +31,7 @@ export const Profile = () => {
   const [passwordError, setPasswordError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!user) return;
+    if (!user?.id) return;
     const loadProfile = async () => {
       try {
         const profile = await authApi.fetchProfile();
@@ -55,7 +55,7 @@ export const Profile = () => {
     };
 
     loadProfile();
-  }, [user, updateUser]);
+  }, [user?.id, updateUser]);
 
   useEffect(() => {
     if (!user || activeTab !== 'addresses') return;

--- a/src/frontend/src/pages/admin/Catalog.tsx
+++ b/src/frontend/src/pages/admin/Catalog.tsx
@@ -5,7 +5,7 @@ import { createCategory, createTag, deleteCategory, deleteTag, updateCategory, u
 import { useAuth } from '../../hooks/useAuth';
 
 export const AdminCatalog: React.FC = () => {
-  const { token } = useAuth();
+  const { user } = useAuth();
   const [categories, setCategories] = useState<Category[]>([]);
   const [tags, setTags] = useState<WellbeingTag[]>([]);
   const [categoryForm, setCategoryForm] = useState({ name: '', description: '' });
@@ -28,11 +28,11 @@ export const AdminCatalog: React.FC = () => {
 
   const handleAddCategory = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!token) return;
+    if (!user) return;
     setErrorMessage(null);
 
     try {
-      await createCategory(token, {
+      await createCategory({
         name: categoryForm.name,
         description: categoryForm.description || undefined,
       });
@@ -45,11 +45,11 @@ export const AdminCatalog: React.FC = () => {
   };
 
   const handleUpdateCategory = async (categoryId: number) => {
-    if (!token) return;
+    if (!user) return;
     setErrorMessage(null);
 
     try {
-      await updateCategory(token, categoryId, {
+      await updateCategory(categoryId, {
         name: editingCategory.name,
         description: editingCategory.description || undefined,
       });
@@ -62,11 +62,11 @@ export const AdminCatalog: React.FC = () => {
   };
 
   const handleDeleteCategory = async (categoryId: number) => {
-    if (!token) return;
+    if (!user) return;
     setErrorMessage(null);
 
     try {
-      await deleteCategory(token, categoryId);
+      await deleteCategory(categoryId);
       await loadData();
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to delete category.';
@@ -76,11 +76,11 @@ export const AdminCatalog: React.FC = () => {
 
   const handleAddTag = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!token) return;
+    if (!user) return;
     setErrorMessage(null);
 
     try {
-      await createTag(token, tagForm);
+      await createTag(tagForm);
       setTagForm({ name: '', type: 'GOAL' });
       await loadData();
     } catch (err) {
@@ -90,11 +90,11 @@ export const AdminCatalog: React.FC = () => {
   };
 
   const handleUpdateTag = async (tagId: number) => {
-    if (!token) return;
+    if (!user) return;
     setErrorMessage(null);
 
     try {
-      await updateTag(token, tagId, editingTag);
+      await updateTag(tagId, editingTag);
       setEditingTagId(null);
       await loadData();
     } catch (err) {
@@ -104,11 +104,11 @@ export const AdminCatalog: React.FC = () => {
   };
 
   const handleDeleteTag = async (tagId: number) => {
-    if (!token) return;
+    if (!user) return;
     setErrorMessage(null);
 
     try {
-      await deleteTag(token, tagId);
+      await deleteTag(tagId);
       await loadData();
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to delete tag.';

--- a/src/frontend/src/pages/admin/OrderDetail.tsx
+++ b/src/frontend/src/pages/admin/OrderDetail.tsx
@@ -9,13 +9,13 @@ const statusOptions = ['PENDING', 'PAID', 'SHIPPED', 'DELIVERED', 'CANCELLED'];
 
 export const AdminOrderDetail: React.FC = () => {
   const { id } = useParams<{ id: string }>();
-  const { token } = useAuth();
+  const { user } = useAuth();
   const [order, setOrder] = useState<OrderResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!token || !id) return;
+    if (!user || !id) return;
     const orderId = Number(id);
     if (Number.isNaN(orderId)) {
       setError('Invalid order ID.');
@@ -23,7 +23,7 @@ export const AdminOrderDetail: React.FC = () => {
       return;
     }
 
-    fetchAdminOrder(token, orderId)
+    fetchAdminOrder(orderId)
       .then((data) => {
         setOrder(data);
         setError(null);
@@ -33,12 +33,12 @@ export const AdminOrderDetail: React.FC = () => {
         setError(message);
       })
       .finally(() => setLoading(false));
-  }, [token, id]);
+  }, [user, id]);
 
   const handleStatusUpdate = async (nextStatus: string) => {
-    if (!token || !order) return;
+    if (!user || !order) return;
     try {
-      const updated = await updateOrderStatus(token, order.id, nextStatus);
+      const updated = await updateOrderStatus(order.id, nextStatus);
       setOrder(updated);
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to update status.';

--- a/src/frontend/src/pages/admin/OrderDetail.tsx
+++ b/src/frontend/src/pages/admin/OrderDetail.tsx
@@ -9,13 +9,27 @@ const statusOptions = ['PENDING', 'PAID', 'SHIPPED', 'DELIVERED', 'CANCELLED'];
 
 export const AdminOrderDetail: React.FC = () => {
   const { id } = useParams<{ id: string }>();
-  const { user } = useAuth();
+  const { user, isLoading: authLoading } = useAuth();
   const [order, setOrder] = useState<OrderResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!user || !id) return;
+    if (authLoading) return;
+
+    if (!id) {
+      setError('Order not found.');
+      setLoading(false);
+      return;
+    }
+
+    if (!user) {
+      setOrder(null);
+      setError('Please sign in to view this order.');
+      setLoading(false);
+      return;
+    }
+
     const orderId = Number(id);
     if (Number.isNaN(orderId)) {
       setError('Invalid order ID.');
@@ -23,17 +37,13 @@ export const AdminOrderDetail: React.FC = () => {
       return;
     }
 
+    setLoading(true);
+    setError(null);
     fetchAdminOrder(orderId)
-      .then((data) => {
-        setOrder(data);
-        setError(null);
-      })
-      .catch((err) => {
-        const message = err instanceof Error ? err.message : 'Failed to load order.';
-        setError(message);
-      })
+      .then((data) => setOrder(data))
+      .catch((err) => setError(err.message))
       .finally(() => setLoading(false));
-  }, [user, id]);
+  }, [user, authLoading, id]);
 
   const handleStatusUpdate = async (nextStatus: string) => {
     if (!user || !order) return;

--- a/src/frontend/src/pages/admin/Users.tsx
+++ b/src/frontend/src/pages/admin/Users.tsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { fetchAdminUsers, type AdminUser, updateAdminUser } from '../../api/admin';
 import { useAuth } from '../../hooks/useAuth';
 
 export const AdminUsers: React.FC = () => {
-  const { token } = useAuth();
+  const { user: currentUser } = useAuth();
 
   const [users, setUsers] = useState<AdminUser[]>([]);
   const [loading, setLoading] = useState(true);
@@ -12,11 +12,9 @@ export const AdminUsers: React.FC = () => {
   const [hasNextPage, setHasNextPage] = useState(false);
   const [updatingId, setUpdatingId] = useState<number | null>(null);
 
-  const canFetch = useMemo(() => Boolean(token), [token]);
-
   useEffect(() => {
     const run = async () => {
-      if (!token) {
+      if (!currentUser) {
         setUsers([]);
         setHasNextPage(false);
         setError('Not authenticated.');
@@ -27,7 +25,7 @@ export const AdminUsers: React.FC = () => {
       setLoading(true);
       setError(null);
       try {
-        const res = await fetchAdminUsers(token, page, 20);
+        const res = await fetchAdminUsers(page, 20);
         setUsers(res.data);
         setHasNextPage(res.hasNextPage);
       } catch (e) {
@@ -40,14 +38,14 @@ export const AdminUsers: React.FC = () => {
     };
 
     void run();
-  }, [token, page]);
+  }, [currentUser, page]);
 
   const onToggleActive = async (user: AdminUser) => {
-    if (!token) return;
+    if (!currentUser) return;
     setUpdatingId(user.id);
     setError(null);
     try {
-      const updated = await updateAdminUser(token, user.id, { isActive: !user.isActive });
+      const updated = await updateAdminUser(user.id, { isActive: !user.isActive });
       setUsers((prev) => prev.map((u) => (u.id === updated.id ? updated : u)));
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to update user');
@@ -57,11 +55,11 @@ export const AdminUsers: React.FC = () => {
   };
 
   const onChangeRole = async (user: AdminUser, role: AdminUser['role']) => {
-    if (!token) return;
+    if (!currentUser) return;
     setUpdatingId(user.id);
     setError(null);
     try {
-      const updated = await updateAdminUser(token, user.id, { role });
+      const updated = await updateAdminUser(user.id, { role });
       setUsers((prev) => prev.map((u) => (u.id === updated.id ? updated : u)));
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to update user');
@@ -77,7 +75,7 @@ export const AdminUsers: React.FC = () => {
         <p className="text-sm text-gray-500 mt-1">Manage customer accounts, roles, and activation status.</p>
       </div>
 
-      {!canFetch && (
+      {!currentUser && (
         <div className="rounded-xl border border-yellow-200 bg-yellow-50 p-4 text-sm text-yellow-800">
           Login as an admin to view users.
         </div>


### PR DESCRIPTION
## Summary

Implements **Issue #22** — migrates JWT authentication from localStorage-based token storage to httpOnly cookies, eliminating XSS token theft vectors.

### What changed

- **Backend auth routes** now set `access_token` and `refresh_token` as httpOnly cookies via `Set-Cookie` headers. Tokens are no longer returned in JSON response bodies.
- **Backend middleware** (`authenticate`, `adminAuth`) reads tokens from cookies first, with Bearer header fallback for backward compatibility.
- **Frontend AuthContext** completely rewritten — no more token/refreshToken state or localStorage. Session bootstraps via `GET /auth/me` on page load.
- **All frontend API modules** (auth, admin, orders, addresses) stripped of `token` parameters and `Authorization` headers. Cookies sent automatically via `credentials: 'include'`.
- **All 10 page/component consumers** updated to use `user` instead of `token` for auth state checks.

### Architecture

```
Browser                          Nginx Proxy                    Express Backend
  │                                  │                               │
  │── POST /api/auth/login ─────────>│── proxy_pass ────────────────>│
  │                                  │                               │── Set-Cookie: access_token (httpOnly, 15m)
  │                                  │                               │── Set-Cookie: refresh_token (httpOnly, 7d)
  │<── { user } + Set-Cookie ────────│<──────────────────────────────│
  │                                  │                               │
  │── GET /api/orders ──────────────>│── proxy_pass ────────────────>│
  │   (cookies sent automatically)   │   (cookies forwarded)         │── extractAccessToken(req)
  │                                  │                               │   1. req.cookies.access_token ✓
  │                                  │                               │   2. Authorization header (fallback)
  │<── { data } ─────────────────────│<──────────────────────────────│
```

### Cookie Configuration

| Property | Development | Production |
|----------|------------|------------|
| `httpOnly` | `true` | `true` |
| `secure` | `false` | `true` |
| `sameSite` | `lax` | `strict` |
| `path` | `/` | `/` |
| Access token `maxAge` | 15 min | 15 min |
| Refresh token `maxAge` | 7 days | 7 days |

### Commits (6)

1. `feat(auth): set httpOnly cookies on login, register, oauth, refresh, and logout`
2. `feat(auth): read access token from httpOnly cookie in auth middleware`
3. `refactor(frontend): remove token params and auth headers from API modules`
4. `refactor(auth): rewrite AuthContext for cookie-based session management`
5. `refactor(frontend): remove token usage from all page and component consumers`
6. `test(auth): add unit tests for extractAccessToken and auth middleware cookie reading`

### Files Changed (24 files, +561 / -297)

**Backend (8 files)**
- `src/backend/src/api/auth.ts` — cookie-based auth routes + `GET /auth/me` endpoint
- `src/backend/src/lib/auth.ts` — `extractAccessToken()` utility
- `src/backend/src/middleware/auth.ts` — cookie-first token reading
- `src/backend/src/middleware/adminAuth.ts` — cookie-first token reading
- `src/backend/tests/unit/extractAccessToken.test.ts` — **NEW** (9 tests)
- `src/backend/tests/unit/authMiddleware.test.ts` — **NEW** (13 tests)
- `src/backend/tests/unit/middleware/adminAuth.test.ts` — updated for cookies
- `src/backend/tests/integration/auth.test.ts` — updated assertions

**Frontend (16 files)**
- `src/frontend/src/api/auth.ts` — removed token params, added `fetchMe()` + `logout()`
- `src/frontend/src/api/admin.ts` — removed token from all 15 functions
- `src/frontend/src/api/orders.ts` — removed token from all 4 functions
- `src/frontend/src/api/addresses.ts` — removed token from both functions
- `src/frontend/src/context/AuthContext.tsx` — full rewrite for cookie-based sessions
- `src/frontend/src/context/AuthContextDefinition.ts` — removed `token` field
- 10 page/component files — replaced `token` with `user` for auth guards

### Testing

| Suite | Result |
|-------|--------|
| Backend unit tests | **56/56 passing** (22 new) |
| Frontend tests | **3/3 passing** |
| Backend lint | 0 errors |
| Frontend lint | 0 errors |
| Frontend build | ✅ passes (354 kB) |

### Security Improvements

- **XSS protection**: Tokens are no longer accessible to JavaScript (`httpOnly: true`)
- **CSRF protection**: `SameSite=Strict` in production prevents cross-site request forgery
- **No token leakage**: Tokens never appear in JSON responses, localStorage, or JS memory
- **Graceful degradation**: Bearer header fallback ensures backward compatibility during rollout

### Acceptance Criteria

- [x] Login/register/OAuth set httpOnly cookies instead of returning tokens in body
- [x] Refresh token rotation reads from cookie, not request body
- [x] Logout clears both cookies server-side
- [x] `GET /auth/me` endpoint for session bootstrap on page load
- [x] Both auth middleware read from cookies with Bearer fallback
- [x] Frontend AuthContext has zero localStorage token usage
- [x] All API modules use `credentials: 'include'` with no manual Authorization headers
- [x] All page/component consumers use `user` instead of `token`
- [x] 22 new unit tests covering cookie extraction and middleware
- [x] Lint and build pass for both workspaces

Closes #22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Secure HTTP-only cookie-based sessions and a new "fetch current session" endpoint.
  * Client APIs: added fetchMe and logout methods.

* **Changes**
  * Tokens moved from responses into cookies; frontend no longer passes tokens to API calls.
  * Client auth state now derived from user info; logout/refresh/OAuth flows clear cookies on error for consistent state.
  * Numerous frontend calls and hooks updated to rely on user presence instead of raw tokens.

* **Tests**
  * Updated and added tests for cookie-based auth and token extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->