### PR TITLE
chore: upgrade GitHub Actions to Node 24 and fix React lint warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,10 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -64,10 +64,10 @@ jobs:
       run:
         working-directory: src/frontend
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -87,10 +87,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && (github.ref == 'refs/heads/production' || github.ref == 'refs/heads/001-health-wellbeing-store')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build Backend
         run: |

--- a/src/frontend/src/pages/OrderDetail.tsx
+++ b/src/frontend/src/pages/OrderDetail.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { cancelOrder, fetchOrder, type OrderResponse } from '../api/orders';
 import { useAuth } from '../hooks/useAuth';
@@ -15,7 +15,7 @@ export const OrderDetail: React.FC = () => {
   const [cancelError, setCancelError] = useState<string | null>(null);
   const [isCancelling, setIsCancelling] = useState(false);
 
-  const loadOrder = async (orderId: number) => {
+  const loadOrder = useCallback(async (orderId: number) => {
     if (!user) return;
     setLoading(true);
     setError(null);
@@ -28,7 +28,7 @@ export const OrderDetail: React.FC = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [user]);
 
   useEffect(() => {
     if (!user) {
@@ -48,7 +48,7 @@ export const OrderDetail: React.FC = () => {
     }
 
     loadOrder(parsedId);
-  }, [id, user]);
+  }, [id, user, loadOrder]);
 
   const handleCancel = async () => {
     if (!user || !order) return;


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout` v4 → v6, `actions/setup-node` v4 → v6, `docker/setup-buildx-action` v3 → v4 (Node.js 20 deprecated June 2026)
- Fix React `useEffect` missing dependency warning in `OrderDetail.tsx` by wrapping `loadOrder` in `useCallback`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow dependencies to latest versions for improved compatibility and security.

* **Refactor**
  * Optimized internal performance handling for the order detail page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->