### PR TITLE
fix: remove catalogService dependency from seed script for production compatibility

### DIFF
--- a/src/backend/prisma/seed.ts
+++ b/src/backend/prisma/seed.ts
@@ -2,7 +2,6 @@ import { Prisma, PrismaClient, UserRole, WellbeingTagType, PaymentProvider, Paym
 import bcrypt from 'bcryptjs';
 import fs from 'fs';
 import path from 'path';
-import { invalidateProductCaches } from '../src/services/catalogService';
 
 const prisma = new PrismaClient();
 
@@ -345,9 +344,9 @@ async function main() {
     });
   }
 
-  // Best-effort cache invalidation so dev UI reflects new seed data immediately.
-  // Safe even if Redis is not running (redis lib handles errors).
-  await invalidateProductCaches();
+  // Cache invalidation removed to allow seed script to run in production
+  // without requiring compiled service dependencies.
+  // In production, caches will be empty on first start anyway.
 
   console.log('Seeding completed.');
 }


### PR DESCRIPTION
## Summary
- Removed `invalidateProductCaches` import and call from seed script
- Allows seed script to run in production Docker container without requiring compiled service dependencies
- Cache invalidation is not critical during initial seeding (caches are empty on first start)

## Problem
The seed script was importing from `../src/services/catalogService`, which doesn't exist in the production Docker container (only compiled JS in `dist/` is available). This prevented database seeding in production.

## Solution
Removed the cache invalidation call since:
1. It's marked as "best-effort" in the original comment
2. In production, caches are empty on first start anyway
3. The seed script can now run with `tsx` without requiring compiled dependencies

## Testing
- Seed script will be tested in production deployment after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data seeding reliability in production environments by removing external service dependencies that prevented the seed script from running independently.
  * Product caches now initialize on first application start in production.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->