### PR TITLE
fix: enable trust proxy for nginx reverse proxy headers

### DIFF
--- a/src/backend/src/app.ts
+++ b/src/backend/src/app.ts
@@ -32,6 +32,9 @@ import { prisma } from './lib/prisma';
 
 const app = express();
 
+// Trust proxy headers from nginx reverse proxy
+app.set('trust proxy', true);
+
 app.use(helmet());
 app.use(cors(buildCorsOptions()));
 app.use(cookieParser());


### PR DESCRIPTION
## Summary
- Added `app.set('trust proxy', true)` to Express configuration
- Fixes rate limiting errors when behind nginx reverse proxy

## Problem
The backend was logging validation errors:
```
ValidationError: The 'X-Forwarded-For' header is set but the Express 'trust proxy' setting is false (default).
```

This happens because nginx sets `X-Forwarded-For` headers when proxying requests, but Express doesn't trust them by default.

## Solution
Enable trust proxy setting so Express correctly handles:
- `X-Forwarded-For` (client IP)
- `X-Forwarded-Proto` (original protocol)
- `X-Forwarded-Host` (original host)

This is required for:
- Accurate rate limiting based on client IP
- Correct redirect URLs (http vs https)
- Security features that depend on client IP

## Testing
- Backend logs should no longer show trust proxy validation errors
- Rate limiting should work correctly with client IPs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated server configuration to properly support proxy headers from nginx.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->