### PR TITLE
feat: add HTTPS/SSL support with Let's Encrypt

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -64,6 +64,12 @@ services:
     container_name: welbeing_frontend
     ports:
       - "80:80"
+      - "443:443"
+    volumes:
+      # Mount SSL certificates from host
+      - /etc/letsencrypt:/etc/letsencrypt:ro
+      # Mount SSL nginx config
+      - ./src/frontend/nginx-ssl.conf:/etc/nginx/conf.d/default.conf:ro
     depends_on:
       - backend
     restart: unless-stopped

--- a/src/frontend/nginx-ssl.conf
+++ b/src/frontend/nginx-ssl.conf
@@ -1,0 +1,63 @@
+# Redirect HTTP to HTTPS
+server {
+    listen 80;
+    server_name welbeing.mindinroot.com;
+    return 301 https://$server_name$request_uri;
+}
+
+# HTTPS server
+server {
+    listen 443 ssl http2;
+    server_name welbeing.mindinroot.com;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # SSL certificates (mounted from host)
+    ssl_certificate /etc/letsencrypt/live/welbeing.mindinroot.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/welbeing.mindinroot.com/privkey.pem;
+
+    # SSL configuration
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+    ssl_prefer_server_ciphers on;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 10m;
+
+    # Enable gzip compression
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript image/svg+xml;
+    gzip_min_length 1000;
+    gzip_comp_level 6;
+
+    # Security headers
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
+    # Serve static assets with caching headers
+    location ~* \.(js|css|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf|eot)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        try_files $uri =404;
+    }
+
+    # Reverse-proxy API requests to the backend service.
+    # Keeps frontend and backend on the same origin so cookies
+    # work with SameSite=Strict and no CORS preflight is needed.
+    location /api/ {
+        proxy_pass http://backend:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Pass cookies through
+        proxy_pass_request_headers on;
+    }
+
+    # All other requests fall back to index.html for SPA client-side routing
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary
- Added HTTPS/SSL support using Let's Encrypt certificates
- Created nginx-ssl.conf with HTTPS configuration
- Updated docker-compose to mount SSL certificates and expose port 443
- Configured HTTP to HTTPS redirect
- Added SSL security headers (HSTS, etc.)

## Changes
1. **New nginx-ssl.conf**: HTTPS-enabled nginx configuration
   - Redirects HTTP (port 80) to HTTPS (port 443)
   - SSL/TLS 1.2 and 1.3 support
   - Strong cipher configuration
   - HSTS header for security

2. **Updated compose.yaml**:
   - Exposed port 443 for HTTPS
   - Mounted `/etc/letsencrypt` from host (SSL certificates)
   - Mounted `nginx-ssl.conf` as nginx config

## SSL Certificate
- Certificate obtained via Let's Encrypt (certbot)
- Valid for 90 days, auto-renewal configured
- Domain: welbeing.mindinroot.com

## Testing
After deployment:
- http://welbeing.mindinroot.com → redirects to HTTPS
- https://welbeing.mindinroot.com → works with valid SSL
- Cloudflare can now proxy properly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Infrastructure**
  * Frontend service now supports HTTPS connections on port 443
  * HTTP traffic automatically redirects to HTTPS
  * SSL/TLS configuration includes security headers (HSTS, XSS protection, Clickjacking prevention)
  * Gzip compression enabled for improved performance
  * Static assets cached with appropriate expiry policies
  * API requests proxied to backend service

<!-- end of auto-generated comment: release notes by coderabbit.ai -->